### PR TITLE
Change text to comment on program page

### DIFF
--- a/program/index.md
+++ b/program/index.md
@@ -2,4 +2,4 @@
 layout: program
 ---
 
-The main categories (or tracks) of the different talks as well as their coloring can be adapted in the `_config.yml` file under `conference.talks.main_categories`. See also the [Talk Settings](https://github.com/DigitaleGesellschaft/jekyll-theme-conference/#talk-settings-main-categories) section of the theme's README file.
+[//]: #The main categories (or tracks) of the different talks as well as their coloring can be adapted in the `_config.yml` file under `conference.talks.main_categories`. See also the [Talk Settings](https://github.com/DigitaleGesellschaft/jekyll-theme-conference/#talk-settings-main-categories) section of the theme's README file.


### PR DESCRIPTION
Found a way to comment out text on a mark down page when displayed on an HTML page using `[//]: # Comment text`

Close #39 